### PR TITLE
Some enhancements about JSON indents

### DIFF
--- a/dotfiles/.editorconfig
+++ b/dotfiles/.editorconfig
@@ -13,3 +13,14 @@ trim_trailing_whitespace = true
 [*.md]
 insert_final_newline = false
 trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab
+indent_size = 4
+
+[*.{diff,md}]
+trim_trailing_whitespace = false
+
+[*.json]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
It is very Common to take JSON files only with 2 indents in case of a deep structure, so you don't have to scroll a lot on the x-angle.

Enable trailing whitespaces on Markdown and diff files.

The [Makefile] Section is recomended.